### PR TITLE
Changes status code of Lockdown to 403 instead of 500

### DIFF
--- a/Api/LockDownInterface.php
+++ b/Api/LockDownInterface.php
@@ -24,8 +24,8 @@ interface LockDownInterface
 {
     const XML_PATH_LOCKDOWN_MODE = 'msp_securitysuite_general/lockdown/stealth';
 
-    const HTTP_LOCKDOWN_CODE = 500;
-    const HTTP_LOCKDOWN_BODY = '<h1>500 Internal Server Error</h1>';
+    const HTTP_LOCKDOWN_CODE = 403;
+    const HTTP_LOCKDOWN_BODY = '<h1>403 Forbidden</h1>';
     const HTTP_LOCKDOWN_PATH = 'msp_security_suite/stop/index';
 
     /**

--- a/Controller/Stop/Index.php
+++ b/Controller/Stop/Index.php
@@ -25,6 +25,7 @@ use Magento\Framework\App\Action\Context;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Result\PageFactory;
 use MSP\SecuritySuiteCommon\Api\SessionInterface;
+use MSP\SecuritySuiteCommon\Api\LockDownInterface;
 
 class Index extends Action
 {
@@ -64,7 +65,7 @@ class Index extends Action
             return null;
         }
 
-        $this->getResponse()->setHttpResponseCode(500);
+        $this->getResponse()->setHttpResponseCode(LockDownInterface::HTTP_LOCKDOWN_CODE);
         $this->registry->register('msp_security_suite_reason', $reason);
         return $this->pageFactory->create();
     }


### PR DESCRIPTION
Lockdown is rather connected to Security 
HTTP 403 is a standard HTTP status code communicated to clients by an HTTP server to indicate that the server understood the request, but will not fulfill it.
500 Internal Server Error is rather to indicate server errors.